### PR TITLE
Fixed error logging on failed requests.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ function ReliableGet(config) {
                         url: options.url,
                         errorMessage: err.message
                     });
-                    self.emit('stat', 'error', 'FAIL ' + message, {tracer:options.tracer, statusCode: statusCode, type:options.type});
+                    self.emit('log', 'error', 'FAIL ' + message, {tracer:options.tracer, statusCode: statusCode, type:options.type});
+                    self.emit('stat', 'increment', options.statsdKey + '.requestError');
                     cb({statusCode: statusCode || 500, message: message, headers: headers});
                 }
             }


### PR DESCRIPTION
Currently, a 'stat' event is fired on HTTP error responses. I think this might be a typo and should be a 'log' event. Also, I've added an actual stat counter called `requestError` that does in fact increment for each error.