### PR TITLE
tes/resources#2783 emit 'cache-control: no-cache, no-store, must-reva…

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function ReliableGet(config) {
             pipeAndCacheContent(function(err, res) {
                 if(err) { return next(err); }
                 res.headers = res.headers || {};
-                res.headers['cache-control'] = 'no-store';
+                res.headers['cache-control'] = 'no-cache, no-store, must-revalidate';
                 next(null, {statusCode: res.statusCode, content: res.content, headers: res.headers, timing: res.timing});
             });
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reliable-get",
-  "version": "0.1.28",
+  "version": "0.1.29",
   "description": "A circuit breaker and cached wrapper for GET requests (enables reliable external service interaction).",
   "main": "index.js",
   "scripts": {

--- a/tests/reliable-get.test.js
+++ b/tests/reliable-get.test.js
@@ -60,6 +60,7 @@ describe("Reliable Get", function() {
       var rg = new ReliableGet(config);
       rg.get({url:'http://localhost:5001/faulty?faulty=false', cacheKey:'__error__'}, function(err, response) {
           expect(err).to.be(null);
+          expect(response.headers['cache-control']).to.be('no-cache, no-store, must-revalidate');
           expect(response.statusCode).to.be(200);
           done();
       });


### PR DESCRIPTION
…lidate' instead of just no-store for responses that should not be cached
tes/resources#2783