### PR TITLE
tes/resources#2783 allow servers to specify their own cache-control h…

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,9 @@ function ReliableGet(config) {
             pipeAndCacheContent(function(err, res) {
                 if(err) { return next(err); }
                 res.headers = res.headers || {};
-                res.headers['cache-control'] = 'no-cache, no-store, must-revalidate';
+                if (!hasCacheControl(res, 'no-cache') || !hasCacheControl(res, 'no-store')) {
+                    res.headers['cache-control'] = 'no-cache, no-store, must-revalidate';
+                }
                 next(null, {statusCode: res.statusCode, content: res.content, headers: res.headers, timing: res.timing});
             });
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reliable-get",
-  "version": "0.1.29",
+  "version": "0.1.30",
   "description": "A circuit breaker and cached wrapper for GET requests (enables reliable external service interaction).",
   "main": "index.js",
   "scripts": {

--- a/tests/reliable-get.test.js
+++ b/tests/reliable-get.test.js
@@ -66,6 +66,17 @@ describe("Reliable Get", function() {
       });
   });
 
+  it('NO CACHE: should just request service if explicitNoCache', function(done) {
+    var config = {cache:{engine:'nocache'}};
+    var rg = new ReliableGet(config);
+    rg.get({url:'http://localhost:5001/nocachecustom', explicitNoCache: true}, function(err, response) {
+      expect(err).to.be(null);
+      expect(response.headers['cache-control']).to.be('no-cache, no-store, must-revalidate, private, max-stale=0, post-check=0, pre-check=0');
+      expect(response.statusCode).to.be(200);
+      done();
+    });
+  });
+
   it('NO CACHE: should fail if timeout exceeded', function(done) {
       var config = {cache:{engine:'nocache'}};
       var rg = new ReliableGet(config);
@@ -225,10 +236,12 @@ describe("Reliable Get", function() {
       rg.get({url:'http://localhost:5001/nocache', cacheKey: 'memory-nocache-1', cacheTTL: 10000}, function(err, response) {
           expect(err).to.be(null);
           expect(response.statusCode).to.be(200);
+          expect(response.headers['cache-control']).to.be('private, max-age=0, no-cache');
           var content = response.content;
           setTimeout(function() {
             rg.get({url:'http://localhost:5001/nocache', cacheKey: 'memory-nocache-1', cacheTTL: 10000}, function(err, response) {
               expect(response.statusCode).to.be(200);
+              expect(response.headers['cache-control']).to.be('private, max-age=0, no-cache');
               expect(response.content).to.not.be(content);
               done();
             });

--- a/tests/stub/server.js
+++ b/tests/stub/server.js
@@ -41,6 +41,11 @@ function initStubServer(port, next) {
             res.end('' + Date.now());
         });
 
+        router.get('/nocachecustom', function(req, res) {
+            res.writeHead(200, {'cache-control': 'no-cache, no-store, must-revalidate, private, max-stale=0, post-check=0, pre-check=0'});
+            res.end('' + Date.now());
+        });
+
         router.get('/maxage', function(req, res) {
             res.writeHead(200, {'cache-control': 'private, max-age=5000'});
             res.end('' + Date.now());


### PR DESCRIPTION
…eader (that must at least have no-cache, and no-store) for error or explicitNoCache cases -- tes/resources#2783