### PR TITLE
gunzip responses with encoding gzip

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,9 @@ function ReliableGet(config) {
     var fallbackDecorator = getFallbackCacheDecorator(cache, {noPush: true, useStale: true});
     var dedupeDecorator = getDedupeDecorator(utils.getCacheKey(config));
 
+
     config.requestOpts = config.requestOpts || { agent: false };
+    config.requestOpts.gzip = true;
     config.requestOpts.followRedirect = config.requestOpts.followRedirect !== false; // make falsey values true
 
     // Backwards compatibility

--- a/lib/getRequest.js
+++ b/lib/getRequest.js
@@ -2,7 +2,6 @@ var request = require('request');
 var sf = require('sf');
 var url = require('url');
 var HTTPError = require('./http-error');
-var zlib = require('zlib');
 var utils = require('./utils');
 var isCachingDisabled = utils.isCachingDisabled;
 var filterHeaders = utils.filterHeaders;
@@ -14,11 +13,10 @@ function getReq(config) {
         var start = Date.now();
 
         // Defaults
-        options.encoding = null;
         options.headers = options.headers || config.headers || {};
         options.timeout = options.hasOwnProperty('timeout') ? options.timeout : 5000;
 
-        var content = new Buffer('', 'base64'), inErrorState = false, res;
+        var content = '', inErrorState = false, res;
 
         var formatError = function (mess) {
             return sf('Service {url} responded with {errorMessage}', {
@@ -43,7 +41,7 @@ function getReq(config) {
             next(new HTTPError(formatError(err.message)));
         })
         .on('data', function(data) {
-            content = Buffer.concat([content, data]);
+            content += data.toString();
         })
         .on('response', function(response) {
             res = response;
@@ -59,21 +57,9 @@ function getReq(config) {
         })
         .on('end', function() {
             if(inErrorState) { return; }
-            if (res.headers['content-encoding'] === 'gzip') {
-                zlib.gunzip(content, function(err, buffer) {
-                    if (!err) {
-                        res.content = buffer.toString();
-                        res.timing = Date.now() - start;
-                        next(null, res);
-                    } else {
-                        next(err);
-                    }
-                });
-            } else {
-                res.content = content.toString();
-                res.timing = Date.now() - start;
-                next(null, res);
-            }
+            res.content = content;
+            res.timing = Date.now() - start;
+            next(null, res);
         });
     };
 }

--- a/lib/getRequest.js
+++ b/lib/getRequest.js
@@ -2,6 +2,7 @@ var request = require('request');
 var sf = require('sf');
 var url = require('url');
 var HTTPError = require('./http-error');
+var zlib = require('zlib');
 var utils = require('./utils');
 var isCachingDisabled = utils.isCachingDisabled;
 var filterHeaders = utils.filterHeaders;
@@ -13,10 +14,11 @@ function getReq(config) {
         var start = Date.now();
 
         // Defaults
+        options.encoding = null;
         options.headers = options.headers || config.headers || {};
         options.timeout = options.hasOwnProperty('timeout') ? options.timeout : 5000;
 
-        var content = '', inErrorState = false, res;
+        var content = new Buffer('', 'base64'), inErrorState = false, res;
 
         var formatError = function (mess) {
             return sf('Service {url} responded with {errorMessage}', {
@@ -41,7 +43,7 @@ function getReq(config) {
             next(new HTTPError(formatError(err.message)));
         })
         .on('data', function(data) {
-            content += data.toString();
+            content = Buffer.concat([content, data]);
         })
         .on('response', function(response) {
             res = response;
@@ -57,9 +59,21 @@ function getReq(config) {
         })
         .on('end', function() {
             if(inErrorState) { return; }
-            res.content = content;
-            res.timing = Date.now() - start;
-            next(null, res);
+            if (res.headers['content-encoding'] === 'gzip') {
+                zlib.gunzip(content, function(err, buffer) {
+                    if (!err) {
+                        res.content = buffer.toString();
+                        res.timing = Date.now() - start;
+                        next(null, res);
+                    } else {
+                        next(err);
+                    }
+                });
+            } else {
+                res.content = content.toString();
+                res.timing = Date.now() - start;
+                next(null, res);
+            }
         });
     };
 }


### PR DESCRIPTION
Use inbuilt request gzip parsing - we should pay close attention to performance when this goes live.