### PR TITLE
Add Memcached cache backend support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - '6.8'
 - '1.5'
 services:
+- memcached
 - redis-server
 notifications:
   hipchat:

--- a/lib/cache/cacheFactory.js
+++ b/lib/cache/cacheFactory.js
@@ -3,9 +3,11 @@ var _ = require('lodash');
 var NOCache = require('memoize-cache/no-cache');
 var Cache = require('memoize-cache/cache');
 var cacheManager = require('cache-manager');
+var memcachedStore = require('cache-manager-memcached-store');
 var redisStore = require('cache-manager-redis');
 var utils = require('../utils');
 var getCacheKey = utils.getCacheKey;
+var getMemcachedConfig = utils.getMemcachedConfig;
 var getRedisConfig = utils.getRedisConfig;
 
 var cleanupPeriod = 60 * 60 * 24; // 1 day
@@ -39,6 +41,12 @@ module.exports = function cacheFactory(config) {
     if (config.cache.engine === 'memorycache' ) {
         CMConfig.store = 'memory';
         CMConfig.ttl = 60;
+    }
+    else if (config.cache.engine === 'memcached') {
+        params = getMemcachedConfig(config.cache);
+        CMConfig.store = memcachedStore;
+        CMConfig.ttl = 60;
+        _.assign(CMConfig, params);
     }
     else if (config.cache.engine === 'redis') {
         params = getRedisConfig(config.cache);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -63,6 +63,10 @@ function filterHeaders(h) {
 		}
 }
 
+function getMemcachedConfig(config) {
+  return { options: config };
+}
+
 function parseRedisConnectionString(connectionString) {
     var params = url.parse(connectionString, true);
     return {
@@ -92,6 +96,7 @@ module.exports = {
 	isCachingDisabled: isCachingDisabled,
 	cacheKeytoStatsd: cacheKeytoStatsd,
   filterHeaders: filterHeaders,
+  getMemcachedConfig: getMemcachedConfig,
 	getRedisConfig: getRedisConfig,
 	getCacheValidity: getCacheValidity
 };

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "async-deco": "^7.0.4",
     "body-parser": "^1.6.7",
     "cache-manager": "^2.0.1",
+    "cache-manager-memcached-store": "^2.1.0",
     "cache-manager-redis": "^0.2.2",
     "connect-route": "^0.1.4",
     "hogan.js": "^3.0.2",

--- a/readme.md
+++ b/readme.md
@@ -59,10 +59,12 @@ var config = {
 
 Property|Description|Example / Default|Required
 ---------|----------|-------------|-------
-cache.engine|Cache to use, redis/memorycache/nocache|nocache|No
+cache.engine|Cache to use, redis/memcached/memorycache/nocache|nocache|No
 cache.engine.url|URL to redis|localhost:6379|No
 cache.compress|Use snappy compression|false|No
 cache.namespace|Prefix for redis keys|''|No
+cache.hosts|Array of host:port combinations for memcached|[]|No
+cache.autodiscover|Use Elasticache Auto Discovery|false|No
 
 ## GET options
 
@@ -122,10 +124,12 @@ Configuration
 Cache configuration
 -------------------
 The cache object accept any config value accepted by redis. It also takes:
-* config.cache.engine: nocache, memorycache, redis (use nocache/memorycache for testing only!)
+* config.cache.engine: nocache, memorycache, memcached, redis (use nocache/memorycache for testing only!)
 * config.cache.url: redis dsn, it is translated to the connection parameters
 * config.cache.compress: enable snappy compression on cached items
 * config.cache.namespace: adds this string as a prefix to any key. Useful to share redis with other services or migrations
+* config.cache.hosts: Memcached cluster nodes addresses as `<host>:<port>` combinartions in an array
+* config.cache.autodiscover: enable AWS Elasticache Auto Discovery of Memcached cache cluster nodes
 
 Request Configuration
 ---------------------


### PR DESCRIPTION
This adds support for Memcached as a storage backend.

Additional supported configuration flags can be found on the Memcached-Plus website http://memcache-plus.com/