### PR TITLE
Bump JS Hint and update Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,13 @@
 language: node_js
 node_js:
-- '6.8'
-- '8.6'
+  - 'node'
+  - '6.8'
+  - '8.6'
+  - '10'
+  - '11'
 services:
-- memcached
-- redis-server
-notifications:
-  hipchat:
-    rooms:
-      secure: FZUOHDpKBfr/54WKT2epXAiRW5B6Tgpg9Bsfvuz5Mg1AOEkdE8kYBjeP9oUegJCUlsXvtO9VE3tf2fdI3hMKNc+yLXgvYDvsmjhTiVXk23of17zH2FTjFdbO/vm4SBSnh6wdg2qHGB8s2Y08uKADojRX6Vnznoy4d+k+nRaZrNA=
+  - memcached
+  - redis-server
 sudo: false
 env:
   - CC=clang CXX=clang++ npm_config_clang=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,7 @@ addons:
       - ubuntu-toolchain-r-test
     packages:
       - g++-4.8
+matrix:
+  allow_failures:
+  - node_js: '11'
+  - node_js: 'node'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "reliable-get",
-  "version": "5.0.6",
+  "version": "5.0.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -14,10 +14,10 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.1.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
       }
     },
     "align-text": {
@@ -26,9 +26,9 @@
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
       "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
       }
     },
     "amdefine": {
@@ -43,7 +43,7 @@
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
       "dev": true,
       "requires": {
-        "sprintf-js": "1.0.3"
+        "sprintf-js": "~1.0.2"
       }
     },
     "asn1": {
@@ -72,14 +72,14 @@
       "resolved": "https://registry.npmjs.org/async-deco/-/async-deco-8.5.0.tgz",
       "integrity": "sha512-euVdCPvpqLg/fSOI4pAHlJiYS93c5sF/bCWy654IaHfOukGTyc67fKtvLmmw+TbuPI84ECiQz3sBOLAvt5LR2w==",
       "requires": {
-        "es6-promisify": "6.0.0",
-        "little-ds-toolkit": "1.0.0",
-        "lodash": "4.17.10",
-        "memoize-cache-utils": "0.1.1",
-        "occamsrazor-match": "4.1.0",
-        "require-all": "2.2.0",
-        "setimmediate": "1.0.5",
-        "uuid": "3.2.1"
+        "es6-promisify": "^6.0.0",
+        "little-ds-toolkit": "^1.0.0",
+        "lodash": "^4.17.5",
+        "memoize-cache-utils": "^0.1.1",
+        "occamsrazor-match": "^4.1.0",
+        "require-all": "^2.2.0",
+        "setimmediate": "^1.0.5",
+        "uuid": "^3.2.1"
       },
       "dependencies": {
         "lodash": {
@@ -116,7 +116,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "bindings": {
@@ -136,15 +136,15 @@
       "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "requires": {
         "bytes": "3.0.0",
-        "content-type": "1.0.4",
+        "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.2",
-        "http-errors": "1.6.3",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
         "iconv-lite": "0.4.23",
-        "on-finished": "2.3.0",
+        "on-finished": "~2.3.0",
         "qs": "6.5.2",
         "raw-body": "2.3.3",
-        "type-is": "1.6.16"
+        "type-is": "~1.6.16"
       }
     },
     "brace-expansion": {
@@ -153,7 +153,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -198,9 +198,9 @@
       "resolved": "https://registry.npmjs.org/cache-manager-redis/-/cache-manager-redis-0.2.6.tgz",
       "integrity": "sha1-jrhouCLmESBqh6+5ZoSL0Ej37nI=",
       "requires": {
-        "cache-manager": "1.5.0",
-        "redis-url": "1.2.1",
-        "sol-redis-pool": "0.3.3"
+        "cache-manager": "^1.2.2",
+        "redis-url": "^1.2.1",
+        "sol-redis-pool": "^0.3.1"
       },
       "dependencies": {
         "async": {
@@ -213,7 +213,7 @@
           "resolved": "https://registry.npmjs.org/cache-manager/-/cache-manager-1.5.0.tgz",
           "integrity": "sha1-UpIUvaV/oZUU0QbwcPq7FsMZCBE=",
           "requires": {
-            "async": "1.5.2",
+            "async": "^1.5.2",
             "lru-cache": "4.0.0"
           }
         }
@@ -243,8 +243,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
       }
     },
     "chai": {
@@ -252,9 +252,9 @@
       "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
       "integrity": "sha1-TQJjewZ/6Vi9v906QOxW/vc3Mkc=",
       "requires": {
-        "assertion-error": "1.1.0",
-        "deep-eql": "0.1.3",
-        "type-detect": "1.0.0"
+        "assertion-error": "^1.0.1",
+        "deep-eql": "^0.1.3",
+        "type-detect": "^1.0.0"
       }
     },
     "cli": {
@@ -264,7 +264,7 @@
       "dev": true,
       "requires": {
         "exit": "0.1.2",
-        "glob": "7.1.2"
+        "glob": "^7.1.1"
       }
     },
     "cliui": {
@@ -274,8 +274,8 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
         "wordwrap": "0.0.2"
       },
       "dependencies": {
@@ -298,7 +298,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "commander": {
@@ -321,7 +321,7 @@
       "requires": {
         "debug": "2.6.9",
         "finalhandler": "1.1.0",
-        "parseurl": "1.3.2",
+        "parseurl": "~1.3.2",
         "utils-merge": "1.0.1"
       }
     },
@@ -341,7 +341,7 @@
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
       "dev": true,
       "requires": {
-        "date-now": "0.1.4"
+        "date-now": "^0.1.4"
       }
     },
     "content-type": {
@@ -381,7 +381,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "date-now": {
@@ -448,8 +448,8 @@
       "integrity": "sha1-BzxpdUbOB4DOI75KKOKT5AvDDII=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.1.3",
-        "entities": "1.1.1"
+        "domelementtype": "~1.1.1",
+        "entities": "~1.1.1"
       },
       "dependencies": {
         "domelementtype": {
@@ -459,17 +459,17 @@
           "dev": true
         },
         "entities": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-          "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
+          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
           "dev": true
         }
       }
     },
     "domelementtype": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
-      "integrity": "sha1-sXrtguirWeUt2cGbF1bg/BhyBMI=",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
+      "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==",
       "dev": true
     },
     "domhandler": {
@@ -478,7 +478,7 @@
       "integrity": "sha1-LeWaCCLVAn+r/28DLCsloqir5zg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0"
+        "domelementtype": "1"
       }
     },
     "domutils": {
@@ -487,8 +487,8 @@
       "integrity": "sha1-3NhIiib1Y9YQeeSMn3t+Mjc2gs8=",
       "dev": true,
       "requires": {
-        "dom-serializer": "0.1.0",
-        "domelementtype": "1.3.0"
+        "dom-serializer": "0",
+        "domelementtype": "1"
       }
     },
     "double-ended-queue": {
@@ -502,7 +502,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "ee-first": {
@@ -550,11 +550,11 @@
       "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
       "dev": true,
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
-        "esutils": "2.0.2",
-        "optionator": "0.8.2",
-        "source-map": "0.2.0"
+        "esprima": "^2.7.1",
+        "estraverse": "^1.9.1",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.2.0"
       }
     },
     "esprima": {
@@ -620,12 +620,12 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.2",
-        "escape-html": "1.0.3",
-        "on-finished": "2.3.0",
-        "parseurl": "1.3.2",
-        "statuses": "1.3.1",
-        "unpipe": "1.0.0"
+        "encodeurl": "~1.0.1",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.3.1",
+        "unpipe": "~1.0.0"
       },
       "dependencies": {
         "statuses": {
@@ -646,9 +646,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "fs.realpath": {
@@ -667,7 +667,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "glob": {
@@ -676,12 +676,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "growl": {
@@ -696,10 +696,10 @@
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "optimist": "0.6.1",
-        "source-map": "0.4.4",
-        "uglify-js": "2.8.29"
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
       },
       "dependencies": {
         "async": {
@@ -714,7 +714,7 @@
           "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
           "dev": true,
           "requires": {
-            "amdefine": "1.0.1"
+            "amdefine": ">=0.0.4"
           }
         }
       }
@@ -729,8 +729,8 @@
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "requires": {
-        "ajv": "5.5.2",
-        "har-schema": "2.0.0"
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
       }
     },
     "has-flag": {
@@ -744,8 +744,8 @@
       "resolved": "https://registry.npmjs.org/hashring/-/hashring-3.2.0.tgz",
       "integrity": "sha1-/aTv3oqiLNuX+x0qZeiEAeHBRM4=",
       "requires": {
-        "connection-parse": "0.0.7",
-        "simple-lru-cache": "0.0.2"
+        "connection-parse": "0.0.x",
+        "simple-lru-cache": "0.0.x"
       }
     },
     "he": {
@@ -775,37 +775,11 @@
       "integrity": "sha1-mWwosZFRaovoZQGn15dX5ccMEGg=",
       "dev": true,
       "requires": {
-        "domelementtype": "1.3.0",
-        "domhandler": "2.3.0",
-        "domutils": "1.5.1",
-        "entities": "1.0.0",
-        "readable-stream": "1.1.14"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-          "dev": true
-        },
-        "readable-stream": {
-          "version": "1.1.14",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "0.0.1",
-            "string_decoder": "0.10.31"
-          }
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
+        "domelementtype": "1",
+        "domhandler": "2.3",
+        "domutils": "1.5",
+        "entities": "1.0",
+        "readable-stream": "1.1"
       }
     },
     "http-errors": {
@@ -813,10 +787,10 @@
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
       "requires": {
-        "depd": "1.1.2",
+        "depd": "~1.1.2",
         "inherits": "2.0.3",
         "setprototypeof": "1.1.0",
-        "statuses": "1.5.0"
+        "statuses": ">= 1.4.0 < 2"
       }
     },
     "http-signature": {
@@ -824,9 +798,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "iconv-lite": {
@@ -834,7 +808,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
       "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "requires": {
-        "safer-buffer": "2.1.2"
+        "safer-buffer": ">= 2.1.2 < 3"
       }
     },
     "immutable": {
@@ -848,8 +822,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -868,6 +842,12 @@
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
+    "isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+      "dev": true
+    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -885,20 +865,20 @@
       "integrity": "sha1-ZcfXPUxNqE1POsMQuRj7C4Azczs=",
       "dev": true,
       "requires": {
-        "abbrev": "1.0.9",
-        "async": "1.5.2",
-        "escodegen": "1.8.1",
-        "esprima": "2.7.3",
-        "glob": "5.0.15",
-        "handlebars": "4.0.11",
-        "js-yaml": "3.11.0",
-        "mkdirp": "0.5.1",
-        "nopt": "3.0.6",
-        "once": "1.4.0",
-        "resolve": "1.1.7",
-        "supports-color": "3.2.3",
-        "which": "1.3.1",
-        "wordwrap": "1.0.0"
+        "abbrev": "1.0.x",
+        "async": "1.x",
+        "escodegen": "1.8.x",
+        "esprima": "2.7.x",
+        "glob": "^5.0.15",
+        "handlebars": "^4.0.1",
+        "js-yaml": "3.x",
+        "mkdirp": "0.5.x",
+        "nopt": "3.x",
+        "once": "1.x",
+        "resolve": "1.1.x",
+        "supports-color": "^3.1.0",
+        "which": "^1.1.1",
+        "wordwrap": "^1.0.0"
       },
       "dependencies": {
         "abbrev": {
@@ -919,11 +899,11 @@
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
           "dev": true,
           "requires": {
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
           }
         },
         "minimist": {
@@ -947,7 +927,7 @@
           "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
           "dev": true,
           "requires": {
-            "abbrev": "1.0.9"
+            "abbrev": "1"
           }
         }
       }
@@ -958,8 +938,8 @@
       "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
       "dev": true,
       "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
       },
       "dependencies": {
         "esprima": {
@@ -977,27 +957,19 @@
       "optional": true
     },
     "jshint": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.9.5.tgz",
-      "integrity": "sha1-HnJSkVzmgbQIJ+4UJIxG006apiw=",
+      "version": "2.10.1",
+      "resolved": "https://registry.npmjs.org/jshint/-/jshint-2.10.1.tgz",
+      "integrity": "sha512-9GpPfKeffYBl7oBDX2lHPG16j0AM7D2bn3aLy9DaWTr6CWa0i/7UGhX8WLZ7V14QQnnr4hXbjauTLYg06F+HYw==",
       "dev": true,
       "requires": {
-        "cli": "1.0.1",
-        "console-browserify": "1.1.0",
-        "exit": "0.1.2",
-        "htmlparser2": "3.8.3",
-        "lodash": "3.7.0",
-        "minimatch": "3.0.4",
-        "shelljs": "0.3.0",
-        "strip-json-comments": "1.0.4"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "3.7.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.7.0.tgz",
-          "integrity": "sha1-Nni9irmVBXwHreg27S7wh9qBHUU=",
-          "dev": true
-        }
+        "cli": "~1.0.0",
+        "console-browserify": "1.1.x",
+        "exit": "0.1.x",
+        "htmlparser2": "3.8.x",
+        "lodash": "~4.17.10",
+        "minimatch": "~3.0.2",
+        "shelljs": "0.3.x",
+        "strip-json-comments": "1.0.x"
       }
     },
     "json-schema": {
@@ -1032,7 +1004,7 @@
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
       "dev": true,
       "requires": {
-        "is-buffer": "1.1.6"
+        "is-buffer": "^1.1.5"
       }
     },
     "lazy-cache": {
@@ -1048,8 +1020,8 @@
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
       }
     },
     "little-ds-toolkit": {
@@ -1073,8 +1045,8 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.0.0.tgz",
       "integrity": "sha1-tcvwFVbBaWb+vlTO7A+03JDfbCg=",
       "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
+        "pseudomap": "^1.0.1",
+        "yallist": "^2.0.0"
       }
     },
     "md5-o-matic": {
@@ -1092,14 +1064,14 @@
       "resolved": "https://registry.npmjs.org/memcache-plus/-/memcache-plus-0.2.16.tgz",
       "integrity": "sha1-GU/Xb2bSyuPqSUurT8zE9qOyZ1c=",
       "requires": {
-        "bluebird": "3.5.1",
-        "carrier": "0.3.0",
-        "chai": "3.5.0",
-        "debug": "2.6.9",
-        "hashring": "3.2.0",
-        "immutable": "3.8.2",
-        "lodash": "4.17.10",
-        "ramda": "0.21.0"
+        "bluebird": "^3.4.1",
+        "carrier": "^0.3.0",
+        "chai": "^3.5.0",
+        "debug": "^2.2.0",
+        "hashring": "^3.2.0",
+        "immutable": "^3.8.1",
+        "lodash": "^4.14.0",
+        "ramda": "^0.21.0"
       },
       "dependencies": {
         "lodash": {
@@ -1114,9 +1086,9 @@
       "resolved": "https://registry.npmjs.org/memoize-cache/-/memoize-cache-5.0.1.tgz",
       "integrity": "sha1-VIrp2pgjMnOGJ/drVPJzZ73LgbM=",
       "requires": {
-        "async-deco": "7.6.0",
+        "async-deco": "^7.6.0",
         "little-ds-toolkit": "0.4.0",
-        "memoize-cache-utils": "0.1.1"
+        "memoize-cache-utils": "^0.1.1"
       },
       "dependencies": {
         "async-deco": {
@@ -1124,14 +1096,14 @@
           "resolved": "https://registry.npmjs.org/async-deco/-/async-deco-7.6.0.tgz",
           "integrity": "sha1-IjBsg2tA5FGu0MIOebxQ0ANKiK0=",
           "requires": {
-            "es6-promisify": "3.0.0",
+            "es6-promisify": "^3.0.0",
             "little-ds-toolkit": "0.2.1",
-            "lodash": "4.17.10",
-            "memoize-cache-utils": "0.0.2",
-            "occamsrazor-match": "4.1.0",
-            "require-all": "2.2.0",
-            "setimmediate": "1.0.5",
-            "uuid": "2.0.3"
+            "lodash": "^4.13.1",
+            "memoize-cache-utils": "^0.0.2",
+            "occamsrazor-match": "^4.0.0",
+            "require-all": "^2.0.0",
+            "setimmediate": "^1.0.4",
+            "uuid": "^2.0.2"
           },
           "dependencies": {
             "little-ds-toolkit": {
@@ -1139,7 +1111,7 @@
               "resolved": "https://registry.npmjs.org/little-ds-toolkit/-/little-ds-toolkit-0.2.1.tgz",
               "integrity": "sha1-ofXMi9x+9BGN2YCwcVHrNwB0KJA=",
               "requires": {
-                "sizeof": "1.0.0"
+                "sizeof": "^1.0.0"
               }
             },
             "memoize-cache-utils": {
@@ -1147,7 +1119,7 @@
               "resolved": "https://registry.npmjs.org/memoize-cache-utils/-/memoize-cache-utils-0.0.2.tgz",
               "integrity": "sha1-B6A0JOb2zuhmxxMebwD52q9u890=",
               "requires": {
-                "md5-o-matic": "0.1.1"
+                "md5-o-matic": "^0.1.1"
               }
             }
           }
@@ -1157,7 +1129,7 @@
           "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-3.0.0.tgz",
           "integrity": "sha1-IiJrkpVzF/llJH7f3pKV+D7+voY=",
           "requires": {
-            "es6-promise": "3.3.1"
+            "es6-promise": "^3.0.2"
           }
         },
         "little-ds-toolkit": {
@@ -1165,7 +1137,7 @@
           "resolved": "https://registry.npmjs.org/little-ds-toolkit/-/little-ds-toolkit-0.4.0.tgz",
           "integrity": "sha1-qdAIxAPW8aQWBg4eTgJ5EcP+7SM=",
           "requires": {
-            "sizeof": "1.0.0"
+            "sizeof": "^1.0.0"
           }
         },
         "lodash": {
@@ -1185,10 +1157,10 @@
       "resolved": "https://registry.npmjs.org/memoize-cache-manager/-/memoize-cache-manager-1.0.1.tgz",
       "integrity": "sha512-fQpVoxtKsIhCMMDKZOL6U4Xg0u1o3PyLmuSWayPWCEwTXE32ehbyiPKk2tyOMByDNSOVYlx12P9fl/S/7bVwsw==",
       "requires": {
-        "async-deco": "7.6.0",
-        "md5-o-matic": "0.1.1",
-        "memoize-cache": "5.0.1",
-        "snappy": "6.0.4"
+        "async-deco": "^7.6.0",
+        "md5-o-matic": "^0.1.1",
+        "memoize-cache": "^5.0.0",
+        "snappy": "^6.0.4"
       },
       "dependencies": {
         "async-deco": {
@@ -1196,14 +1168,14 @@
           "resolved": "https://registry.npmjs.org/async-deco/-/async-deco-7.6.0.tgz",
           "integrity": "sha1-IjBsg2tA5FGu0MIOebxQ0ANKiK0=",
           "requires": {
-            "es6-promisify": "3.0.0",
+            "es6-promisify": "^3.0.0",
             "little-ds-toolkit": "0.2.1",
-            "lodash": "4.17.10",
-            "memoize-cache-utils": "0.0.2",
-            "occamsrazor-match": "4.1.0",
-            "require-all": "2.2.0",
-            "setimmediate": "1.0.5",
-            "uuid": "2.0.3"
+            "lodash": "^4.13.1",
+            "memoize-cache-utils": "^0.0.2",
+            "occamsrazor-match": "^4.0.0",
+            "require-all": "^2.0.0",
+            "setimmediate": "^1.0.4",
+            "uuid": "^2.0.2"
           }
         },
         "es6-promisify": {
@@ -1211,7 +1183,7 @@
           "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-3.0.0.tgz",
           "integrity": "sha1-IiJrkpVzF/llJH7f3pKV+D7+voY=",
           "requires": {
-            "es6-promise": "3.3.1"
+            "es6-promise": "^3.0.2"
           }
         },
         "little-ds-toolkit": {
@@ -1219,7 +1191,7 @@
           "resolved": "https://registry.npmjs.org/little-ds-toolkit/-/little-ds-toolkit-0.2.1.tgz",
           "integrity": "sha1-ofXMi9x+9BGN2YCwcVHrNwB0KJA=",
           "requires": {
-            "sizeof": "1.0.0"
+            "sizeof": "^1.0.0"
           }
         },
         "lodash": {
@@ -1232,7 +1204,7 @@
           "resolved": "https://registry.npmjs.org/memoize-cache-utils/-/memoize-cache-utils-0.0.2.tgz",
           "integrity": "sha1-B6A0JOb2zuhmxxMebwD52q9u890=",
           "requires": {
-            "md5-o-matic": "0.1.1"
+            "md5-o-matic": "^0.1.1"
           }
         },
         "uuid": {
@@ -1247,10 +1219,10 @@
       "resolved": "https://registry.npmjs.org/memoize-cache-redis/-/memoize-cache-redis-1.0.3.tgz",
       "integrity": "sha512-6tudjtClwPzMASd4s/1KbR88jLM0dY1D99+aYQhkJ6x15CfgXaXGneFxjaO7DnWXuBc+BzT6cmFSu+8W5NG64Q==",
       "requires": {
-        "async-deco": "7.6.0",
-        "memoize-cache": "5.0.1",
-        "redis": "2.8.0",
-        "snappy": "6.0.4"
+        "async-deco": "^7.6.0",
+        "memoize-cache": "^5.0.0",
+        "redis": "^2.7.1",
+        "snappy": "^6.0.4"
       },
       "dependencies": {
         "async-deco": {
@@ -1258,14 +1230,14 @@
           "resolved": "https://registry.npmjs.org/async-deco/-/async-deco-7.6.0.tgz",
           "integrity": "sha1-IjBsg2tA5FGu0MIOebxQ0ANKiK0=",
           "requires": {
-            "es6-promisify": "3.0.0",
+            "es6-promisify": "^3.0.0",
             "little-ds-toolkit": "0.2.1",
-            "lodash": "4.17.10",
-            "memoize-cache-utils": "0.0.2",
-            "occamsrazor-match": "4.1.0",
-            "require-all": "2.2.0",
-            "setimmediate": "1.0.5",
-            "uuid": "2.0.3"
+            "lodash": "^4.13.1",
+            "memoize-cache-utils": "^0.0.2",
+            "occamsrazor-match": "^4.0.0",
+            "require-all": "^2.0.0",
+            "setimmediate": "^1.0.4",
+            "uuid": "^2.0.2"
           }
         },
         "bindings": {
@@ -1279,7 +1251,7 @@
           "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-3.0.0.tgz",
           "integrity": "sha1-IiJrkpVzF/llJH7f3pKV+D7+voY=",
           "requires": {
-            "es6-promise": "3.3.1"
+            "es6-promise": "^3.0.2"
           }
         },
         "little-ds-toolkit": {
@@ -1287,7 +1259,7 @@
           "resolved": "https://registry.npmjs.org/little-ds-toolkit/-/little-ds-toolkit-0.2.1.tgz",
           "integrity": "sha1-ofXMi9x+9BGN2YCwcVHrNwB0KJA=",
           "requires": {
-            "sizeof": "1.0.0"
+            "sizeof": "^1.0.0"
           }
         },
         "lodash": {
@@ -1300,7 +1272,7 @@
           "resolved": "https://registry.npmjs.org/memoize-cache-utils/-/memoize-cache-utils-0.0.2.tgz",
           "integrity": "sha1-B6A0JOb2zuhmxxMebwD52q9u890=",
           "requires": {
-            "md5-o-matic": "0.1.1"
+            "md5-o-matic": "^0.1.1"
           }
         },
         "nan": {
@@ -1315,8 +1287,8 @@
           "integrity": "sha512-+MjETxi/G7fLtiLFWW9n9VLzpJvOVqRRohJ7kTgaU4bUJ37rsoWwxhZzO91BOB7sCgOILtKsGtCUviUo3REIfQ==",
           "optional": true,
           "requires": {
-            "bindings": "1.3.0",
-            "nan": "2.10.0"
+            "bindings": "^1.3.0",
+            "nan": "^2.10.0"
           }
         },
         "uuid": {
@@ -1331,7 +1303,7 @@
       "resolved": "https://registry.npmjs.org/memoize-cache-utils/-/memoize-cache-utils-0.1.1.tgz",
       "integrity": "sha1-6TgcW/V1zU0Ai+pJtXzWrkgHT7s=",
       "requires": {
-        "md5-o-matic": "0.1.1"
+        "md5-o-matic": "^0.1.1"
       }
     },
     "mime-db": {
@@ -1344,7 +1316,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "minimatch": {
@@ -1353,7 +1325,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -1422,7 +1394,7 @@
           "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "dev": true,
           "requires": {
-            "has-flag": "3.0.0"
+            "has-flag": "^3.0.0"
           }
         }
       }
@@ -1443,7 +1415,7 @@
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "requires": {
-        "abbrev": "1.1.1"
+        "abbrev": "1"
       }
     },
     "oauth-sign": {
@@ -1470,7 +1442,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "optimist": {
@@ -1479,8 +1451,8 @@
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
       "dev": true,
       "requires": {
-        "minimist": "0.0.10",
-        "wordwrap": "0.0.3"
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
       },
       "dependencies": {
         "wordwrap": {
@@ -1497,12 +1469,12 @@
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
       "dev": true,
       "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
       }
     },
     "parseurl": {
@@ -1565,14 +1537,26 @@
         "unpipe": "1.0.0"
       }
     },
+    "readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "dev": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
     "redis": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/redis/-/redis-2.8.0.tgz",
       "integrity": "sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==",
       "requires": {
-        "double-ended-queue": "2.1.0-0",
-        "redis-commands": "1.3.5",
-        "redis-parser": "2.6.0"
+        "double-ended-queue": "^2.1.0-0",
+        "redis-commands": "^1.2.0",
+        "redis-parser": "^2.6.0"
       }
     },
     "redis-commands": {
@@ -1590,7 +1574,7 @@
       "resolved": "https://registry.npmjs.org/redis-url/-/redis-url-1.2.1.tgz",
       "integrity": "sha1-GGcAlaOOmJ03k1ndTG5Kv/heLrE=",
       "requires": {
-        "redis": "2.8.0"
+        "redis": ">= 0.0.1"
       }
     },
     "repeat-string": {
@@ -1604,26 +1588,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.7.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.1",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.0.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.18",
-        "oauth-sign": "0.8.2",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.3.4",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
       }
     },
     "require-all": {
@@ -1644,7 +1628,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "align-text": "0.1.4"
+        "align-text": "^0.1.1"
       }
     },
     "safe-buffer": {
@@ -1697,8 +1681,8 @@
       "integrity": "sha512-+MjETxi/G7fLtiLFWW9n9VLzpJvOVqRRohJ7kTgaU4bUJ37rsoWwxhZzO91BOB7sCgOILtKsGtCUviUo3REIfQ==",
       "optional": true,
       "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.10.0"
+        "bindings": "^1.3.0",
+        "nan": "^2.10.0"
       }
     },
     "sol-redis-pool": {
@@ -1706,9 +1690,9 @@
       "resolved": "https://registry.npmjs.org/sol-redis-pool/-/sol-redis-pool-0.3.3.tgz",
       "integrity": "sha1-pxEdb4lCQTugrUczVmFnBS23Sms=",
       "requires": {
-        "bluebird": "3.5.1",
+        "bluebird": "^3.4.6",
         "generic-pool": "2.2.1",
-        "redis": "2.8.0"
+        "redis": ">= 2.6.2"
       }
     },
     "source-map": {
@@ -1718,7 +1702,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "amdefine": "1.0.1"
+        "amdefine": ">=0.0.4"
       }
     },
     "sprintf-js": {
@@ -1732,20 +1716,26 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
       "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "1.0.4",
@@ -1759,7 +1749,7 @@
       "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
       "dev": true,
       "requires": {
-        "has-flag": "1.0.0"
+        "has-flag": "^1.0.0"
       }
     },
     "tough-cookie": {
@@ -1767,7 +1757,7 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
       "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
       "requires": {
-        "punycode": "1.4.1"
+        "punycode": "^1.4.1"
       }
     },
     "tunnel-agent": {
@@ -1775,7 +1765,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.2"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -1790,7 +1780,7 @@
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
       "dev": true,
       "requires": {
-        "prelude-ls": "1.1.2"
+        "prelude-ls": "~1.1.2"
       }
     },
     "type-detect": {
@@ -1804,7 +1794,7 @@
       "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.18"
+        "mime-types": "~2.1.18"
       }
     },
     "uglify-js": {
@@ -1814,9 +1804,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
       },
       "dependencies": {
         "source-map": {
@@ -1871,9 +1861,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "which": {
@@ -1882,7 +1872,7 @@
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "window-size": {
@@ -1921,9 +1911,9 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "camelcase": "1.2.1",
-        "cliui": "2.1.0",
-        "decamelize": "1.2.0",
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
         "window-size": "0.1.0"
       }
     }

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "expect.js": "~0.3.1",
     "heapdump": "^0.3.7",
     "istanbul": "^0.4.5",
-    "jshint": "^2.5.6",
+    "jshint": "^2.10.1",
     "mocha": "^5.2.0",
     "precommit-hook": "^1.0.7"
   },


### PR DESCRIPTION
This PR:
- Bumps `jshint`, see https://nodesecurity.io/advisories/577
- Removes HipChat noise from `.travis.yml`. If we want notifications, we should consider adding a Slack notification instead.
- Specifies more recent node versions for the tests to run on. The build fails on node 11, so we should look into that. I've added node 11 to a list of allowed failures until we're ready to support it.

I'll bump the version once merged and publish to npm.